### PR TITLE
update FOP version to 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu
 
 # set path for the FOP installation
-ENV PATH "$PATH:/usr/local/fop-2.5/fop"
+ENV PATH "$PATH:/usr/local/fop-2.6/fop"
 
 # update lists of packages
 RUN apt-get update
@@ -14,10 +14,10 @@ RUN apt-get install -y default-jre
 RUN apt-get install -y wget
 
 # get the version 2.5 of FOP
-RUN wget http://ftp.download-by.net/apache/xmlgraphics/fop/binaries/fop-2.5-bin.tar.gz
+RUN wget http://ftp.download-by.net/apache/xmlgraphics/fop/binaries/fop-2.6-bin.tar.gz
 
 # unpack FOP into /usr/local
-RUN tar -xvzf fop-2.5-bin.tar.gz -C /usr/local
+RUN tar -xvzf fop-2.6-bin.tar.gz -C /usr/local
 
 # entrypoint 
 ENTRYPOINT ["fop"]


### PR DESCRIPTION
Hi @chrwahl,

This PR updates the FOP to the latest version (2.6) for the docker image.